### PR TITLE
Scale correctly when both `maxWidth` && `maxHeight` are specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ imageScaler.getScaledCanvas(imageUrl, options).then((canvas) => {
 
 #### Options:
 
-  - `width` - to scale to (height will adjust proportionally)
+  - `maxWidth` - to scale to (height will adjust proportionally)
+  - `maxHeight` - to scale to (width will adjust proportionally)
   - `canvas` - canvas DOM node that will be used to perform the scaling (one will be created, if not provided)
   - `imageSmoothingEnabled` - property of the canvas context
   - `imageSmoothingQuality` - property of the canvas context

--- a/src/getScaledDimensions.js
+++ b/src/getScaledDimensions.js
@@ -1,0 +1,24 @@
+function scaleWidth(aspectRatio, max, imageWidth) {
+  const width = max < imageWidth ? max : imageWidth;
+  const height = aspectRatio * width;
+  return [width, height];
+}
+
+function scaleHeight(aspectRatio, max, imageHeight) {
+  const height = max < imageHeight ? max : imageHeight;
+  const width = height / aspectRatio;
+  return [width, height];
+}
+
+export default function getScaledDimensions(image, maxWidth, maxHeight) {
+  let scaledWidth = image.width;
+  let scaledHeight = image.height;
+  const aspectRatio = scaledHeight / scaledWidth;
+  if (maxWidth) {
+    [scaledWidth, scaledHeight] = scaleWidth(aspectRatio, maxWidth, image.width);
+  }
+  if (maxHeight) {
+    [scaledWidth, scaledHeight] = scaleHeight(aspectRatio, maxHeight, scaledHeight);
+  }
+  return [scaledWidth, scaledHeight];
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import getLoadedImage from './getLoadedImage';
+import getScaledDimensions from './getScaledDimensions';
 
 function getScaledCanvas(imageUrl, options) {
   let {
@@ -15,17 +16,11 @@ function getScaledCanvas(imageUrl, options) {
 
   return getLoadedImage(imageUrl)
   .then((image) => {
-    if (maxWidth) {
-      maxWidth = (maxWidth < image.width) ? maxWidth : image.width;
-      maxHeight = Math.round(image.height / image.width * maxWidth);
-    }
-    else if (maxHeight) {
-      maxHeight = (maxHeight < image.height) ? maxHeight : image.height;
-      maxWidth = Math.round(image.width / image.height * maxHeight);
-    }
-    else {
+    if (!maxWidth && !maxHeight) {
       throw new Error('either options.maxWidth or options.maxHeight are required');
     }
+
+    [maxWidth, maxHeight] = getScaledDimensions(image, maxWidth, maxHeight);
 
     canvas.width = maxWidth;
     canvas.height = maxHeight;

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -34,6 +34,30 @@ describe('scaler', function() {
       }, done.fail);
     });
 
+    it('should scale down provided both height and width (width smaller than height)', function(done) {
+      unit.getScaledUrl(starImageUrl, { maxWidth: 4, maxHeight: 8 })
+        .then((scaledUrl) => {
+          return getLoadedImage(scaledUrl)
+          .then((image) => {
+            expect(image.naturalHeight).toEqual(4);
+            expect(image.naturalWidth).toEqual(4);
+            done();
+          });
+        }, done.fail);
+    });
+
+    it('should scale down provided both height and width (height smaller than width)', function(done) {
+      unit.getScaledUrl(starImageUrl, { maxWidth: 8, maxHeight: 4 })
+        .then((scaledUrl) => {
+          return getLoadedImage(scaledUrl)
+          .then((image) => {
+            expect(image.naturalHeight).toEqual(4);
+            expect(image.naturalWidth).toEqual(4);
+            done();
+          });
+        }, done.fail);
+    });
+
     it('should not scale up for height', function(done) {
       unit.getScaledUrl(starImageUrl, { maxHeight: 32 })
       .then((scaledUrl) => {


### PR DESCRIPTION
This allows you to specify both `maxWidth` __and__ `maxHeight`, and ensures that the scaled image fits within these limits.

Tests included.

Thanks :+1: 